### PR TITLE
Add flag to enable/disable ingress

### DIFF
--- a/helm/decisionlens/templates/dlc-ingress.yaml
+++ b/helm/decisionlens/templates/dlc-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 ---
 kind: Ingress
 apiVersion: networking.k8s.io/v1
@@ -37,4 +38,4 @@ spec:
               number: {{ .port }}
       {{- end -}}
   {{- end }}
-
+{{- end }}

--- a/helm/decisionlens/templates/dlx-ingress.yaml
+++ b/helm/decisionlens/templates/dlx-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 kind: Ingress
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -36,4 +37,4 @@ spec:
               number: {{ .port }}
       {{- end -}}
   {{- end }}
-
+{{- end }}

--- a/helm/decisionlens/values.yaml
+++ b/helm/decisionlens/values.yaml
@@ -12,6 +12,7 @@ analytics:
   google: true
 
 ingress:
+  enabled: true
   ingressClassName: nginx
   dlx:
     annotations: {}


### PR DESCRIPTION
If a user wants to manage their own ingress then they need to be allowed to disable DL's ingress service.  This is usefull when transitioning to something like Kubernetes API Gateway.
